### PR TITLE
Add disable_tls and sender_name options

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,11 +4,13 @@
   "logfile": "",
 
   "email_from": "",
+  "email_display_name": "GOES-notify Alerts",
   "email_to": [""],
   "email_server": "localhost",
   "email_port": 25,
   "email_username": "",
   "email_password": "",
+  "email_disable_tls": false,
 
   "__comment": "Below are optional:",
   "use_gmail": true,


### PR DESCRIPTION
This PR adds two additional email configuration settings:

- `email_display_name` sets the display name of the sender. Useful when you have multiple services that use the same outbound email address, so you know which alerts are coming from where. 
- `email_disable_tls` will disable STARTTLS on outbound mail. I have no idea how many people actually would use this option, but I needed it because I run an internal Postfix mail relay that intentionally has no encryption options enabled (it's for local services only, so it's safe). 

Both features are backwards-compatible with old config files -- not including either of these settings simply results in the old default behaviours. 