### PR TITLE
Add enrollment_location_name to config file for use in alert message

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you're running this on a machine you'll be using while it's searching, you ca
 
 With the `use_gmail` config setting, you can send yourself an email when an appointment is found. Note: if you have two-factor authentication enabled for your account, you'll need to [generate an app-specific password](https://myaccount.google.com/apppasswords) and add that to `config.json`.
 
-If you would like to check multiple nearby locations at once you need to make copies the original file you just edited and change the location code on each config file. Then in seperate windows run each copy of the diffrent locations.
+If you would like to check multiple nearby locations at once you need to make copies the original file you just edited and change the location code on each config file. Then in seperate windows run each copy of the diffrent locations. If you set `enrollment_location_name` in the config file, the alert message will display this name, otherwise the `enrollment_location_id` will be displayed. 
 
 # Using Docker
 

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
   "current_interview_date_str": "",
   "enrollment_location_id": "",
+  "enrollment_location_name": "",
   "logfile": "",
 
   "email_from": "",


### PR DESCRIPTION
Thanks @Drewster727 for providing this. 

Here are some small additions to (optionally) display the location name in the alerts. This is particularly useful when searching multiple enrollment centers. 